### PR TITLE
Let Hound Bot use Rubocop rules

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml


### PR DESCRIPTION
The Hound bot has its own set of rules to validate code. I want the users of this app to configure their rules using `.rubocop.yml`.